### PR TITLE
fix(ci): exclude Lob detector

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -46,4 +46,6 @@ jobs:
       - name: Secret Scanning
         uses: trufflesecurity/trufflehog@6f3c981e7b77f235fd2702dd74af25fc4b72bf11 # v3.96.0
         with:
-          extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore
+          # Lob detector excluded as Python test function names match Lob `\b(live|test)_[a-zA-Z0-9_]{35}\b` 
+          # pattern causing false-positive "verified" findings. This repo does not use the Lob postal API.
+          extra_args: --results=verified,unknown --exclude-paths=.trufflehogignore --exclude-detectors=Lob


### PR DESCRIPTION
This PR exclude Lob detector causing false positives, [example](https://github.com/open-edge-platform/datumaro/actions/runs/31607870964).

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
