### PR TITLE
Make lazy media/mask loaders picklable

### DIFF
--- a/src/datumaro/experimental/converters/image_converters.py
+++ b/src/datumaro/experimental/converters/image_converters.py
@@ -883,5 +883,4 @@ class ImagePathToImageCallableConverter(MediaBridgeConverter):
 
             callables.append(_ImagePathLoader(str(path), self.input_path.field.format))
 
-
         return df.with_columns(pl.Series(output_col, callables, dtype=pl.Object()))

--- a/src/datumaro/experimental/converters/image_converters.py
+++ b/src/datumaro/experimental/converters/image_converters.py
@@ -1,6 +1,7 @@
 # Copyright (C) 2025 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
+from dataclasses import dataclass
 from typing import Any
 
 import cv2
@@ -812,6 +813,27 @@ class ImagePathToImageInfoConverter(MediaBridgeConverter):
         )
 
 
+@dataclass(frozen=True)
+class _ImagePathLoader:
+    """Picklable callable that lazily loads an image from *path* on demand.
+
+    Used in place of a locally-defined closure so that datasets containing this
+    callable can be passed to ``torch.utils.data.DataLoader`` workers started
+    with the ``spawn`` multiprocessing context, which requires every object
+    reachable from the ``Dataset`` to be picklable. A closure defined inside a
+    function is not picklable by the standard ``pickle`` module, whereas a
+    module-level dataclass instance with simple attributes is.
+    """
+
+    path: str
+    format: str
+
+    def __call__(self) -> np.ndarray:
+        from datumaro.experimental.media import LazyImage
+
+        return LazyImage(path=self.path, format=self.format).data
+
+
 @converter
 class ImagePathToImageCallableConverter(MediaBridgeConverter):
     """
@@ -849,8 +871,6 @@ class ImagePathToImageCallableConverter(MediaBridgeConverter):
         Returns:
             DataFrame with callable column that loads images on demand
         """
-        from datumaro.experimental.media import LazyImage
-
         input_col = self.input_path.name
         output_col = self.output_callable.name
 
@@ -861,12 +881,7 @@ class ImagePathToImageCallableConverter(MediaBridgeConverter):
                 callables.append(None)
                 continue
 
-            def make_loader(p: str, fmt: str) -> callable:
-                def load_image() -> np.ndarray:
-                    return LazyImage(path=p, format=fmt).data
+            callables.append(_ImagePathLoader(str(path), self.input_path.field.format))
 
-                return load_image
-
-            callables.append(make_loader(str(path), self.input_path.field.format))
 
         return df.with_columns(pl.Series(output_col, callables, dtype=pl.Object()))

--- a/src/datumaro/experimental/converters/media_converters.py
+++ b/src/datumaro/experimental/converters/media_converters.py
@@ -207,7 +207,6 @@ class MediaPathToImageCallableConverter(MediaBridgeConverter):
 
             callables.append(_MediaPathLoader(str(path), frame_idx, self.input_media.field.format))
 
-
         return df.with_columns(pl.Series(output_col, callables, dtype=pl.Object()))
 
 

--- a/src/datumaro/experimental/converters/media_converters.py
+++ b/src/datumaro/experimental/converters/media_converters.py
@@ -12,6 +12,7 @@ MediaPathField.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import polars as pl
@@ -132,6 +133,31 @@ class MediaPathToImageConverter(MediaBridgeConverter):
         )
 
 
+@dataclass(frozen=True)
+class _MediaPathLoader:
+    """Picklable callable that lazily loads an image or video frame on demand.
+
+    Used in place of a locally-defined closure so that datasets containing this
+    callable can be passed to ``torch.utils.data.DataLoader`` workers started
+    with the ``spawn`` multiprocessing context, which requires every object
+    reachable from the ``Dataset`` to be picklable. A closure defined inside a
+    function is not picklable by the standard ``pickle`` module, whereas a
+    module-level dataclass instance with simple attributes is.
+    """
+
+    path: str
+    frame_index: int | None
+    format: str
+
+    def __call__(self) -> np.ndarray:
+        media = (
+            LazyVideoFrame(video_path=self.path, frame_index=self.frame_index, format=self.format)
+            if self.frame_index is not None
+            else LazyImage(path=self.path, format=self.format)
+        )
+        return media.data
+
+
 @converter
 class MediaPathToImageCallableConverter(MediaBridgeConverter):
     """
@@ -179,18 +205,8 @@ class MediaPathToImageCallableConverter(MediaBridgeConverter):
                 callables.append(None)
                 continue
 
-            # Create a closure that loads the media on demand
-            def make_loader(p: str, idx: int | None, fmt: str) -> callable:
-                def load_media() -> np.ndarray:
-                    if idx is not None:
-                        media = LazyVideoFrame(video_path=p, frame_index=idx, format=fmt)
-                    else:
-                        media = LazyImage(path=p, format=fmt)
-                    return media.data
+            callables.append(_MediaPathLoader(str(path), frame_idx, self.input_media.field.format))
 
-                return load_media
-
-            callables.append(make_loader(str(path), frame_idx, self.input_media.field.format))
 
         return df.with_columns(pl.Series(output_col, callables, dtype=pl.Object()))
 

--- a/src/datumaro/experimental/converters/video_converters.py
+++ b/src/datumaro/experimental/converters/video_converters.py
@@ -10,6 +10,7 @@ This module provides converters for transforming video frame references
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import polars as pl
@@ -118,6 +119,30 @@ class VideoFramePathToImageConverter(MediaBridgeConverter):
         )
 
 
+@dataclass(frozen=True)
+class _VideoFramePathLoader:
+    """Picklable callable that lazily loads a single video frame on demand.
+
+    Used in place of a locally-defined closure so that datasets containing this
+    callable can be passed to ``torch.utils.data.DataLoader`` workers started
+    with the ``spawn`` multiprocessing context, which requires every object
+    reachable from the ``Dataset`` to be picklable. A closure defined inside a
+    function is not picklable by the standard ``pickle`` module, whereas a
+    module-level dataclass instance with simple attributes is.
+    """
+
+    video_path: str
+    frame_index: int
+    format: str
+
+    def __call__(self) -> np.ndarray:
+        return LazyVideoFrame(
+            video_path=self.video_path,
+            frame_index=self.frame_index,
+            format=self.format,
+        ).data
+
+
 @converter
 class VideoFrameToImageCallableConverter(MediaBridgeConverter):
     """
@@ -165,19 +190,7 @@ class VideoFrameToImageCallableConverter(MediaBridgeConverter):
                 callables.append(None)
                 continue
 
-            # Create a closure that loads the frame on demand
-            def make_loader(p: str, idx: int, fmt: str) -> callable:
-                def load_frame() -> np.ndarray:
-                    frame = LazyVideoFrame(
-                        video_path=p,
-                        frame_index=idx,
-                        format=fmt,
-                    )
-                    return frame.data
-
-                return load_frame
-
-            callables.append(make_loader(str(path), frame_idx, self.input_frame.field.format))
+            callables.append(_VideoFramePathLoader(str(path), frame_idx, self.input_frame.field.format))
 
         return df.with_columns(pl.Series(output_col, callables, dtype=pl.Object()))
 

--- a/src/datumaro/experimental/data_formats/voc/helpers.py
+++ b/src/datumaro/experimental/data_formats/voc/helpers.py
@@ -458,23 +458,35 @@ def _parse_object_element(
     )
 
 
-def _create_mask_loader(mask_path: Path, colormap: dict[tuple[int, int, int], int] | None = None) -> Callable:
-    """Create a lazy loader function for a segmentation mask.
+@dataclass(frozen=True)
+class _VocMaskLoader:
+    """Picklable callable that lazily loads a VOC segmentation mask on demand.
+
+    Used in place of a locally-defined closure so that datasets containing this
+    callable can be passed to ``torch.utils.data.DataLoader`` workers started
+    with the ``spawn`` multiprocessing context, which requires every object
+    reachable from the ``Dataset`` to be picklable. A closure defined inside a
+    function is not picklable by the standard ``pickle`` module, whereas a
+    module-level dataclass instance with simple (picklable) attributes is.
 
     Args:
-        mask_path: Path to the mask PNG file
+        mask_path: Path to the mask PNG file.
         colormap: Optional RGB-to-index mapping. If provided, RGB masks will be
             converted to index masks.
     """
-    from PIL import Image as PILImage
 
-    def load_mask() -> np.ndarray:
+    mask_path: Path
+    colormap: dict[tuple[int, int, int], int] | None = None
+
+    def __call__(self) -> np.ndarray:
         """Load mask from file and convert to numpy array."""
-        with PILImage.open(mask_path) as img:
+        from PIL import Image as PILImage
+
+        with PILImage.open(self.mask_path) as img:
             mask_rgb = np.array(img, dtype=np.uint8)
 
         # If no colormap or already indexed, return as-is
-        if colormap is None or len(mask_rgb.shape) < 3:
+        if self.colormap is None or len(mask_rgb.shape) < 3:
             return mask_rgb
 
         # Convert RGB mask to index mask using colormap
@@ -482,14 +494,23 @@ def _create_mask_loader(mask_path: Path, colormap: dict[tuple[int, int, int], in
         index_mask = np.zeros((h, w), dtype=np.uint8)
 
         # Create a lookup from RGB tuples to indices
-        for rgb, idx in colormap.items():
+        for rgb, idx in self.colormap.items():
             # Find pixels matching this color
             mask = np.all(mask_rgb[:, :, :3] == np.array(rgb), axis=2)
             index_mask[mask] = idx
 
         return index_mask
 
-    return load_mask
+
+def _create_mask_loader(mask_path: Path, colormap: dict[tuple[int, int, int], int] | None = None) -> Callable:
+    """Create a lazy loader callable for a segmentation mask.
+
+    Args:
+        mask_path: Path to the mask PNG file
+        colormap: Optional RGB-to-index mapping. If provided, RGB masks will be
+            converted to index masks.
+    """
+    return _VocMaskLoader(mask_path, colormap)
 
 
 @dataclass

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -1345,12 +1345,12 @@ def _update_dataframe_with_field(
         if field_name in df.columns:
             df = df.drop(field_name)
         return df.with_columns(pl.Series(field_name, values, dtype=pl.String()))
-    if field_name in df.columns:
-        # Callable fields (e.g. lazy image/mask loaders) must be forced to ``pl.Object()``:
-        # letting Polars infer the dtype from a list of callables is unreliable -- e.g. a
-        # dataclass-based loader (which exposes named attributes) can be misidentified as a
-        # nested struct, raising ``InvalidOperation: nested objects are not allowed``.
-        return df.with_columns(pl.Series(field_name, values, dtype=pl.Object()))
+    # Callable fields (e.g. lazy image/mask loaders) must be forced to ``pl.Object()``:
+    # letting Polars infer the dtype from a list of callables is unreliable -- e.g. a
+    # dataclass-based loader (which exposes named attributes) can be misidentified as a
+    # nested struct, raising ``InvalidOperation: nested objects are not allowed``.
+    # ``with_columns`` adds the column when absent and replaces it when present, so a
+    # single branch handles both cases.
     return df.with_columns(pl.Series(field_name, values, dtype=pl.Object()))
 
 

--- a/src/datumaro/experimental/export_import.py
+++ b/src/datumaro/experimental/export_import.py
@@ -23,6 +23,7 @@ import platform
 import re
 import shutil
 import tempfile
+from dataclasses import dataclass
 from enum import Enum
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
@@ -1163,16 +1164,30 @@ def _load_dataframe(input_dir: Path) -> pl.DataFrame:
     return pl.read_parquet(parquet_path)
 
 
-def _make_image_loader(path: Path):
-    """Create a closure that loads an image from a path."""
+@dataclass(frozen=True)
+class _ImageFileLoader:
+    """Picklable callable that lazily loads an image from *path* on demand.
 
-    def load_image():
+    Used in place of a locally-defined closure so that datasets containing this
+    callable can be passed to ``torch.utils.data.DataLoader`` workers started
+    with the ``spawn`` multiprocessing context, which requires every object
+    reachable from the ``Dataset`` to be picklable. A closure defined inside a
+    function is not picklable by the standard ``pickle`` module, whereas a
+    module-level dataclass instance with simple (picklable) attributes is.
+    """
+
+    path: Path
+
+    def __call__(self) -> np.ndarray:
         # Apply EXIF orientation so the loaded array matches the image as
         # displayed (consistent with LazyImage).
-        with Image.open(path) as img:
+        with Image.open(self.path) as img:
             return np.array(ImageOps.exif_transpose(img))
 
-    return load_image
+
+def _make_image_loader(path: Path) -> _ImageFileLoader:
+    """Create a picklable lazy loader callable for an image path."""
+    return _ImageFileLoader(path)
 
 
 def _build_index_based_lookup(field_name: str, images_base_dir: Path) -> dict[int, Path]:
@@ -1331,7 +1346,11 @@ def _update_dataframe_with_field(
             df = df.drop(field_name)
         return df.with_columns(pl.Series(field_name, values, dtype=pl.String()))
     if field_name in df.columns:
-        return df.with_columns(pl.Series(field_name, values))
+        # Callable fields (e.g. lazy image/mask loaders) must be forced to ``pl.Object()``:
+        # letting Polars infer the dtype from a list of callables is unreliable -- e.g. a
+        # dataclass-based loader (which exposes named attributes) can be misidentified as a
+        # nested struct, raising ``InvalidOperation: nested objects are not allowed``.
+        return df.with_columns(pl.Series(field_name, values, dtype=pl.Object()))
     return df.with_columns(pl.Series(field_name, values, dtype=pl.Object()))
 
 

--- a/src/datumaro/experimental/fields/images.py
+++ b/src/datumaro/experimental/fields/images.py
@@ -451,7 +451,7 @@ class ImageCallableField(Field):
         """Store callable as Object in Polars series."""
         if not callable(value) and value is not None:
             raise TypeError(f"Expected callable, got {type(value)}")
-        return {name: pl.Series(name, [value])}
+        return {name: pl.Series(name, [value], dtype=pl.Object())}
 
     def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type) -> typing.Callable:  # noqa: ARG002
         """Extract callable from Polars dataframe."""

--- a/src/datumaro/experimental/fields/masks.py
+++ b/src/datumaro/experimental/fields/masks.py
@@ -221,7 +221,7 @@ class InstanceMaskCallableField(Field):
         """
         if not callable(value) and value is not None:
             raise TypeError(f"Expected callable, got {type(value)}")
-        return {name: pl.Series(name, [value])}
+        return {name: pl.Series(name, [value], dtype=pl.Object())}
 
     def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type) -> Callable:  # noqa: ARG002
         """
@@ -307,7 +307,7 @@ class MaskCallableField(Field):
         """
         if not callable(value) and value is not None:
             raise TypeError(f"Expected callable, got {type(value)}")
-        return {name: pl.Series(name, [value])}
+        return {name: pl.Series(name, [value], dtype=pl.Object())}
 
     def from_polars(self, name: str, row_index: int, df: pl.DataFrame, target_type: type) -> Callable:  # noqa: ARG002
         """

--- a/src/datumaro/experimental/fields/videos.py
+++ b/src/datumaro/experimental/fields/videos.py
@@ -494,7 +494,7 @@ class VideoFrameCallableField(Field):
         """Store callable as Object in Polars series."""
         if not callable(value) and value is not None:
             raise TypeError(f"Expected callable, got {type(value)}")
-        return {name: pl.Series(name, [value])}
+        return {name: pl.Series(name, [value], dtype=pl.Object())}
 
     def from_polars(
         self,

--- a/src/datumaro/plugins/data_formats/arrow/mapper/media.py
+++ b/src/datumaro/plugins/data_formats/arrow/mapper/media.py
@@ -141,12 +141,14 @@ class ImageMapper(MediaElementMapper):
             )
 
         return Image.from_bytes(
-            data=lambda: pa.ipc.open_file(pa.memory_map(table_path, "r"))
-            .read_all()
-            .column("media")[idx]
-            .get("image")
-            .get("bytes")
-            .as_py(),
+            data=lambda: (
+                pa.ipc.open_file(pa.memory_map(table_path, "r"))
+                .read_all()
+                .column("media")[idx]
+                .get("image")
+                .get("bytes")
+                .as_py()
+            ),
             size=image_struct.get("size").as_py(),
         )
 
@@ -161,11 +163,9 @@ class ImageMapper(MediaElementMapper):
             )
 
         return Image.from_bytes(
-            data=lambda: table.column("media")[idx]
-            .get("point_cloud")
-            .get("extra_images")[extra_image_idx]
-            .get("bytes")
-            .as_py(),
+            data=lambda: (
+                table.column("media")[idx].get("point_cloud").get("extra_images")[extra_image_idx].get("bytes").as_py()
+            ),
             size=image_struct.get("size").as_py(),
         )
 

--- a/src/datumaro/plugins/data_formats/cifar.py
+++ b/src/datumaro/plugins/data_formats/cifar.py
@@ -188,9 +188,9 @@ class CifarImporter(Importer):
                     "cifar",
                     # Subset files have no extension in the format, and
                     # should not be the meta file.
-                    file_filter=lambda p: not osp.isdir(p)
-                    and not osp.splitext(osp.basename(p))[1]
-                    and osp.basename(p) != meta_file_name,
+                    file_filter=lambda p: (
+                        not osp.isdir(p) and not osp.splitext(osp.basename(p))[1] and osp.basename(p) != meta_file_name
+                    ),
                 )
 
             return sources

--- a/tests/unit/experimental/test_pickle_serialization.py
+++ b/tests/unit/experimental/test_pickle_serialization.py
@@ -307,6 +307,84 @@ class ForwardMaskAnnotationConverterPickleTest:
         assert output_masks.shape == (2, 2, 2)
 
 
+class LazyLoaderPicklabilityRegressionTest:
+    """Regression tests for the picklable dataclass loaders introduced to make
+    lazy media/mask loaders survive ``torch.utils.data.DataLoader`` ``spawn``
+    pickling.
+
+    These guard against two regressions:
+    - reverting to non-picklable closures (only module-level callables survive
+      ``spawn`` pickling), and
+    - the ``InvalidOperation: nested objects are not allowed`` Polars error that
+      occurs when such loaders (which expose named attributes) are stored in a
+      callable column without an explicit ``pl.Object()`` dtype.
+    """
+
+    def test_image_file_loader_is_picklable(self, tmp_path):
+        """``_ImageFileLoader`` used during export/import must round-trip."""
+        from PIL import Image
+
+        from datumaro.experimental.export_import import _ImageFileLoader
+
+        img_path = tmp_path / "img.png"
+        Image.fromarray(np.zeros((4, 4, 3), dtype=np.uint8)).save(img_path)
+
+        loader = _ImageFileLoader(img_path)
+        assert loader().shape == (4, 4, 3)
+
+        restored = pickle.loads(pickle.dumps(loader))
+        assert restored().shape == (4, 4, 3)
+
+    def test_image_path_loader_is_picklable(self, tmp_path):
+        """``_ImagePathLoader`` used by ImagePathToImageCallableConverter must round-trip."""
+        from PIL import Image
+
+        from datumaro.experimental.converters.image_converters import _ImagePathLoader
+
+        img_path = tmp_path / "img.png"
+        Image.fromarray(np.zeros((4, 4, 3), dtype=np.uint8)).save(img_path)
+
+        loader = _ImagePathLoader(str(img_path), "RGB")
+        assert loader().shape == (4, 4, 3)
+
+        restored = pickle.loads(pickle.dumps(loader))
+        assert restored().shape == (4, 4, 3)
+
+    def test_voc_mask_loader_is_picklable(self, tmp_path):
+        """``_VocMaskLoader`` used for VOC segmentation masks must round-trip."""
+        from PIL import Image
+
+        from datumaro.experimental.data_formats.voc.helpers import _VocMaskLoader
+
+        mask_path = tmp_path / "mask.png"
+        Image.fromarray(np.zeros((4, 4), dtype=np.uint8), mode="L").save(mask_path)
+
+        loader = _VocMaskLoader(mask_path, None)
+        assert loader().shape == (4, 4)
+
+        restored = pickle.loads(pickle.dumps(loader))
+        assert restored().shape == (4, 4)
+
+    def test_dataset_with_loader_callable_column_is_picklable(self, tmp_path):
+        """A Dataset storing dataclass loaders in a callable column must pickle."""
+        from PIL import Image
+
+        from datumaro.experimental.converters.image_converters import _ImagePathLoader
+
+        ds = Dataset(PicklableSample)
+
+        img_path = tmp_path / "img.png"
+        Image.fromarray(np.zeros((4, 4, 3), dtype=np.uint8)).save(img_path)
+        loader = _ImagePathLoader(str(img_path), "RGB")
+
+        ds.append(PicklableSample(image=loader))
+        assert pl.Object in ds.df.schema.values()
+
+        restored = pickle.loads(pickle.dumps(ds))
+        assert len(restored) == 1
+        assert restored[0].image().shape == (4, 4, 3)
+
+
 class ConvertFromLegacyPickleTest:
     """Tests for convert_from_legacy producing picklable datasets."""
 


### PR DESCRIPTION
Replace locally-defined closures (nested functions returned from a factory) used for lazy image, video-frame, and VOC mask loading with module-level picklable dataclass callables.

Closures defined inside a function cannot be pickled by the standard 'pickle' module (only module-level functions/classes are picklable by qualified reference). Datasets containing these closures crash when handed to a torch.utils.data.DataLoader started with the 'spawn' multiprocessing context (required for CUDA/XPU-safe worker startup in many training frameworks), since 'spawn' must pickle the entire Dataset object graph to send it to worker processes.

Affected converters:
- ImagePathToImageCallableConverter (image_converters.py)
- MediaPathToImageCallableConverter (media_converters.py)
- VideoFrameToImageCallableConverter (video_converters.py)
- _create_mask_loader for VOC segmentation masks (voc/helpers.py)
- _make_image_loader used during dataset export/import round-tripping (export_import.py)

Also fixes a latent bug in _update_dataframe_with_field (export_import.py): the 'field already exists in dataframe' branch reconstructed the callable column via 'pl.Series(field_name, values)' without an explicit dtype. Since picklable dataclass-based loaders expose named attributes, Polars can misidentify the column as a nested struct and raise 'InvalidOperation: nested objects are not allowed'. The fix forces dtype=pl.Object() explicitly, as the sibling branch already does.



<!-- Contributing guide: https://github.com/open-edge-platform/datumaro/blob/develop/contributing.md -->

<!--
Please add a summary of changes. You may use Copilot to auto-generate the PR description but please consider including any other relevant facts which Copilot may be unaware of (such as design choices and testing procedure).

Add references to the relevant issues and pull requests if any like so:

Resolves #111 and #222.
Depends on #1000 (for series of dependent commits).
-->

### Checklist
<!-- Put an 'x' in all the boxes that apply -->
- [ ] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly
