### PR TITLE
Fix tiling of RLE-encoded masks

### DIFF
--- a/src/datumaro/plugins/tiling/tile.py
+++ b/src/datumaro/plugins/tiling/tile.py
@@ -5,6 +5,8 @@
 from copy import deepcopy
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+import numpy as np
+from pycocotools import mask as mask_utils
 from shapely import LineString, MultiPoint, box, transform
 from shapely import Polygon as ShapelyPolygon
 from shapely.geometry.base import BaseGeometry
@@ -18,6 +20,7 @@ from datumaro.components.annotation import (
     Points,
     Polygon,
     PolyLine,
+    RleMask,
 )
 from datumaro.components.cli_plugin import CliPlugin
 from datumaro.components.dataset_base import DatasetItem
@@ -41,6 +44,11 @@ def _apply_offset(geom: BaseGeometry, roi_box: ShapelyPolygon) -> BaseGeometry:
 def _tile_mask(ann: Mask, roi_int: BboxIntCoords, *args, **kwargs) -> Mask:
     x, y, w, h = roi_int
     tiled_mask = ann.image[y : y + h, x : x + w]
+    if isinstance(ann, RleMask):
+        return ann.wrap(
+            rle=mask_utils.encode(np.asfortranarray(tiled_mask)),
+            attributes=deepcopy(ann.attributes),
+        )
     return ann.wrap(
         image=tiled_mask,
         attributes=deepcopy(ann.attributes),

--- a/src/datumaro/plugins/tiling/tile.py
+++ b/src/datumaro/plugins/tiling/tile.py
@@ -46,7 +46,7 @@ def _tile_mask(ann: Mask, roi_int: BboxIntCoords, *args, **kwargs) -> Mask:
     tiled_mask = ann.image[y : y + h, x : x + w]
     if isinstance(ann, RleMask):
         return ann.wrap(
-            rle=mask_utils.encode(np.asfortranarray(tiled_mask)),
+            rle=mask_utils.encode(np.asfortranarray(tiled_mask.astype(np.uint8))),
             attributes=deepcopy(ann.attributes),
         )
     return ann.wrap(

--- a/tests/unit/test_tiling.py
+++ b/tests/unit/test_tiling.py
@@ -6,6 +6,8 @@ from typing import Dict, List
 from unittest import TestCase
 
 import numpy as np
+import pytest
+from pycocotools import mask as mask_utils
 from shapely import Polygon as ShapelyPolygon
 from shapely import box
 
@@ -20,6 +22,7 @@ from datumaro.components.annotation import (
     Points,
     Polygon,
     PolyLine,
+    RleMask,
     SuperResolutionAnnotation,
 )
 from datumaro.components.dataset import Dataset
@@ -646,3 +649,67 @@ class MergeTileTest(_TestBase, TestCase):
                 .transform("merge_tile")
             )
             compare_datasets(self, transformed, source, require_media=True)
+
+
+@pytest.mark.parametrize("mask_type", ["dense", "rle", "lazy_rle"])
+def test_tile_mask_preserves_pixels_and_metadata(mask_type):
+    pixels = np.zeros((6, 8), dtype=np.uint8)
+    pixels[1:5, 2:7] = 1
+    metadata = dict(id=7, label=0, group=3, object_id=11, z_order=2, attributes={"nested": {"value": 1}})
+    if mask_type == "dense":
+        annotation = Mask(pixels, **metadata)
+    else:
+        rle = mask_utils.encode(np.asfortranarray(pixels))
+        annotation = RleMask(rle if mask_type == "rle" else lambda: rle, **metadata)
+    source = Dataset.from_iterable(
+        [DatasetItem("sample", media=Image.from_numpy(np.zeros((6, 8, 3), dtype=np.uint8)), annotations=[annotation])],
+        categories=["object"],
+    )
+
+    tiled = list(Tile(source, grid_size=(2, 2), overlap=(0.0, 0.0), threshold_drop_ann=0.5))
+
+    assert len(tiled) == 4
+    for item, (y, x) in zip(tiled, [(0, 0), (0, 4), (3, 0), (3, 4)]):
+        assert len(item.annotations) == 1
+        result = item.annotations[0]
+        np.testing.assert_array_equal(result.image, pixels[y : y + 3, x : x + 4])
+        assert (result.id, result.label, result.group, result.object_id, result.z_order) == (7, 0, 3, 11, 2)
+        assert result.attributes == {"nested": {"value": 1}}
+        assert isinstance(result, type(annotation))
+    tiled[0].annotations[0].attributes["nested"]["value"] = 2
+    assert annotation.attributes == {"nested": {"value": 1}}
+    assert tiled[1].annotations[0].attributes == {"nested": {"value": 1}}
+    np.testing.assert_array_equal(annotation.image, pixels)
+
+
+def test_tile_imported_datumaro_mask_can_be_exported(tmp_path):
+    pixels = np.zeros((6, 8), dtype=np.uint8)
+    pixels[1:5, 2:7] = 1
+    source = Dataset.from_iterable(
+        [
+            DatasetItem(
+                "sample",
+                media=Image.from_numpy(np.zeros((6, 8, 3), dtype=np.uint8)),
+                annotations=[Mask(pixels, id=7, label=0, group=3, z_order=2, attributes={"name": "object"})],
+            )
+        ],
+        categories=["object"],
+    )
+    source.export(str(tmp_path / "source"), "datumaro", save_media=True)
+    imported = Dataset.import_from(str(tmp_path / "source"), "datumaro")
+    assert isinstance(imported.get("sample").annotations[0], RleMask)
+
+    imported.transform(Tile, grid_size=(2, 2), overlap=(0.0, 0.0), threshold_drop_ann=0.5)
+    imported.export(str(tmp_path / "tiled"), "datumaro", save_media=True)
+    restored = Dataset.import_from(str(tmp_path / "tiled"), "datumaro")
+
+    assert len(restored) == 4
+    for idx, (y, x) in enumerate([(0, 0), (0, 4), (3, 0), (3, 4)]):
+        item = restored.get(f"sample_tile_{idx}")
+        assert item.media.size == (3, 4)
+        assert item.media.data.shape == (3, 4, 3)
+        assert len(item.annotations) == 1
+        annotation = item.annotations[0]
+        np.testing.assert_array_equal(annotation.image, pixels[y : y + 3, x : x + 4])
+        assert (annotation.id, annotation.label, annotation.group, annotation.z_order) == (7, 0, 3, 2)
+        assert annotation.attributes == {"name": "object"}


### PR DESCRIPTION
Resolves #1732.

Tiling a Datumaro dataset with RLE-encoded masks fails during export because the cropped dense mask is passed to `RleMask` as `image=`, although the wrapper expects encoded `rle=` data. Encode the cropped pixels before wrapping the annotation, while leaving dense-mask handling unchanged.

The tests cover dense, encoded, and callable encoded masks; exact cropped pixels and metadata; and a generated Datumaro import → tile → export → import round trip.

### Checklist

- [x] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the documentation accordingly.

### Validation

- `tests/unit/test_tiling.py`: 18 passed
- Relevant tiling, annotation, transform, dataset, Datumaro-format, and CLI-transform suites: 273 passed, 11 skipped, 8 subtests passed
- Applicable pre-commit hooks pass: Ruff, Bandit, gitleaks, formatting, and EOF checks

Assisted-by: OpenAI Codex
