### PR TITLE
Fix Kaggle describe text output

### DIFF
--- a/src/datumaro/cli/commands/downloaders/kaggle.py
+++ b/src/datumaro/cli/commands/downloaders/kaggle.py
@@ -95,9 +95,9 @@ class KaggleDatasetDownloader(IDatasetDownloader):
                 raise CliException(f"Failed to import dataset: {e}")
 
     @classmethod
-    def describe(cls, report_format="txt", report_file=None) -> None:
+    def describe(cls, report_format="text", report_file=None) -> None:
         file = report_file if report_file else None
-        if report_format == "txt":
+        if report_format == "text":
             print(cls.get_command_description(), file=file)
 
     @classmethod

--- a/tests/integration/cli/test_download.py
+++ b/tests/integration/cli/test_download.py
@@ -256,11 +256,14 @@ class DownloadDescribeTest:
 
         assert redirected_output == stdout_output
 
-    @pytest.mark.skipif(not KAGGLE_API_KEY_EXISTS, reason="Kaggle API key missing")
-    def test_kaggle(self):
-        run(
-            self._helper_tc,
-            "download",
-            "kaggle",
-            "describe",
-        )
+
+class KaggleDownloadDescribeTest:
+    _helper_tc = TestCaseHelper()
+
+    def test_text(self):
+        output_file = io.StringIO()
+
+        with contextlib.redirect_stdout(output_file):
+            run(self._helper_tc, "download", "kaggle", "describe")
+
+        assert "Supported datasets:" in output_file.getvalue()


### PR DESCRIPTION
Resolves #1841.

Align Kaggle's `describe()` implementation with the shared CLI's `text` report-format value. The previous `txt` comparison made `datum download kaggle describe` succeed without emitting its bundled dataset information.

The regression test does not require Kaggle credentials because `describe` only reads bundled metadata; it does not call the Kaggle API.

### Checklist

- [x] I have added tests to cover my changes or documented any manual tests.
- [ ] I have updated the [documentation](https://github.com/open-edge-platform/datumaro/tree/develop/docs) accordingly

### Validation

- `tests/integration/cli/test_download.py::KaggleDownloadDescribeTest`: 1 passed (the test fails against the previous source because stdout is empty)
- Applicable pre-commit hooks pass: Ruff, Bandit, gitleaks, formatting, and EOF checks
- The full CLI integration directory could not collect locally because this host has no Rust compiler to build Datumaro's native module; this change does not touch that module.

Assisted-by: OpenAI Codex
